### PR TITLE
Harden keep-alive workflow as UptimeRobot backup

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -5,11 +5,18 @@ name: Keep-Alive Heartbeat
 # outside Render: Render decides whether to spin a free service down based on
 # inbound external HTTP traffic, and a self-ping from inside the app cannot
 # wake it once the service has already gone to sleep.
+#
+# NOTE: The primary keep-alive is an external UptimeRobot monitor (5-minute
+# interval) hitting the same /api/health URL. This workflow is a secondary
+# backup. GitHub's scheduled runs are best-effort and can be delayed or
+# skipped under load, so it must not be relied on as the only pinger.
 
 on:
   schedule:
-    # Every 10 minutes — comfortably under Render's ~15 minute idle window.
-    - cron: '*/10 * * * *'
+    # Every 5 minutes, offset off the top of the hour (:02, :07, :12, ...).
+    # Five-minute spacing gives ~3 attempts inside Render's ~15 minute idle
+    # window, and the offset avoids GitHub's busiest, most-throttled slots.
+    - cron: '2-59/5 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -19,5 +26,7 @@ jobs:
     steps:
       - name: Ping /api/health
         run: |
-          curl --fail --silent --show-error --max-time 20 \
+          # 60s timeout so a single cold-start wake-up (which can take ~30-60s
+          # on Render's free tier) does not flag the run as failed.
+          curl --fail --silent --show-error --max-time 60 \
             https://inmailer.onrender.com/api/health


### PR DESCRIPTION
## Summary
- Reworked the GitHub Actions keep-alive workflow to act as a **secondary backup** behind an external UptimeRobot monitor (the new primary keep-alive).
- Changed the cron from `*/10 * * * *` to `2-59/5 * * * *` — every 5 minutes, offset off the top of the hour.
- Raised the `curl --max-time` from 20s to 60s so a single cold-start wake-up does not flag the run red.

## Why
The previous every-10-minute schedule left almost no margin against Render's ~15-minute idle window. GitHub's scheduled runs are best-effort and were delayed/skipped, so the backend idled out and shut down (observed in the Render logs: one ping, then 15 minutes later a SIGTERM). UptimeRobot (5-min interval) now handles keep-alive reliably; this workflow remains as a low-cost backup with tighter spacing and an offset to avoid GitHub's busiest slots.

## Testing
- Confirmed the workflow YAML is valid and the cron parses to `2-59/5 * * * *`.
- Confirmed the heartbeat command still targets the public `/api/health` endpoint.
- Verified the diff is isolated to `.github/workflows/keep-alive.yml`; no unrelated files changed.

## Notes
- UptimeRobot is the primary keep-alive and is configured in its dashboard (no code).
- GitHub scheduled workflows are still best-effort, which is why this is a backup rather than the sole mechanism. Cold starts immediately after a deploy or platform restart remain possible.